### PR TITLE
Fixes #6 providing clients the ability to specify producer options

### DIFF
--- a/lib/emque/producing/configuration.rb
+++ b/lib/emque/producing/configuration.rb
@@ -2,15 +2,17 @@ module Emque
   module Producing
     class Configuration
       attr_accessor :app_name
-      attr_accessor :seed_brokers
       attr_accessor :error_handlers
       attr_accessor :log_publish_message
+      attr_accessor :kafka_seed_brokers
+      attr_accessor :kafka_producer_options
 
       def initialize
         @app_name = ""
-        @seed_brokers = ["localhost:9092"]
         @error_handlers = []
         @log_publish_message = false
+        @kafka_seed_brokers = ["localhost:9092"]
+        @kafka_producer_options = {}
       end
     end
   end

--- a/lib/emque/producing/producing.rb
+++ b/lib/emque/producing/producing.rb
@@ -7,8 +7,8 @@ module Emque
 
       def configure
         yield(configuration)
-        self.poseidon_producer ||= Poseidon::Producer.new(configuration.seed_brokers,
-          "producer_#{host_name}_#{Process.pid}")
+        self.poseidon_producer ||= Poseidon::Producer.new(configuration.kafka_seed_brokers,
+          "producer_#{host_name}_#{Process.pid}", configuration.kafka_producer_options)
       end
 
       def configuration

--- a/spec/producing/configuration_spec.rb
+++ b/spec/producing/configuration_spec.rb
@@ -5,8 +5,8 @@ describe Emque::Producing::Configuration do
 
   it "provides default values" do
     expect(subject.app_name).to eq ""
-    expect(subject.seed_brokers).to eq ["localhost:9092"]
     expect(subject.error_handlers).to eq []
+    expect(subject.kafka_seed_brokers).to eq ["localhost:9092"]
   end
 
   it "allows app_name to be overwritten" do
@@ -15,7 +15,7 @@ describe Emque::Producing::Configuration do
   end
 
   it "allows seed_brokers to be overwritten" do
-    subject.seed_brokers = ["kafka1:9092", "kafka2:9092"]
-    expect(subject.seed_brokers).to eq ["kafka1:9092", "kafka2:9092"]
+    subject.kafka_seed_brokers = ["kafka1:9092", "kafka2:9092"]
+    expect(subject.kafka_seed_brokers).to eq ["kafka1:9092", "kafka2:9092"]
   end
 end


### PR DESCRIPTION
Also making kafka options more clear by prefixing, allowing for other producing methods.
