### PR TITLE
Clean up the gemspec/gems to be more clear

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
 source 'https://rubygems.org'
 
 gemspec
-gem "bunny", "~> 1.4.1"
-gem "poseidon", "0.0.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,4 +61,4 @@ DEPENDENCIES
   poseidon (= 0.0.4)
   pry
   rake
-  rspec (>= 3.0.0)
+  rspec (~> 3.1)

--- a/emque-producing.gemspec
+++ b/emque-producing.gemspec
@@ -26,6 +26,8 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.0"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec", ">= 3.0.0"
+  spec.add_development_dependency "rspec", "~> 3.1"
   spec.add_development_dependency "pry"
+  spec.add_development_dependency "poseidon", "0.0.4"
+  spec.add_development_dependency "bunny", "~> 1.4.1"
 end


### PR DESCRIPTION
This update moves the poseidon and bunny requirements to the development dependencies to make it more clear that this gem will not provide them.  Also, update Rspec requirement to avoid pulling in new major versions.
