### PR TITLE
Fixes #10 makes messages mandatory and raise if not sent

### DIFF
--- a/lib/emque/producing/message/message.rb
+++ b/lib/emque/producing/message/message.rb
@@ -86,7 +86,7 @@ module Emque
           log "valid...", true
           sent = publisher.publish(topic, message_type, to_json, partition_key)
           log "sent #{sent}"
-          #raise MessagesNotSentError.new unless sent
+          raise MessagesNotSentError.new unless sent
         else
           log "failed...", true
           raise InvalidMessageError.new(invalid_message)


### PR DESCRIPTION
The goal here is to avoid message loss. With RabbitMQ, if there are no queues bound to an exchange and you publish to that exchange the message will be dropped.  Making it `mandatory` will handle this situation by returning the message to us in order to do something with it.  That something we want to do with it is retry it in sidekiq/resque after addressing the root problem.  

This update implements the same interface that the kafka publisher had with a return of true or false to represent the fact that the messages was sent. It also removes the exception handling so that both 1) exceptions during publishing and 2) messages not being sent (are mandatory and returned) would fail the publish job in resque/sidekiq so that the publish job can be retried when the problems have been addressed.
