### PR TITLE
Rescue exceptions from message if raise_on_failure? is false

### DIFF
--- a/emque-producing.gemspec
+++ b/emque-producing.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec",   "~> 3.2.0"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "bunny", "~> 1.7.0"
+  spec.add_development_dependency "simplecov"
 end

--- a/lib/emque/producing/configuration.rb
+++ b/lib/emque/producing/configuration.rb
@@ -7,6 +7,7 @@ module Emque
       attr_accessor :log_publish_message
       attr_accessor :publish_messages
       attr_reader :rabbitmq_options
+      attr_accessor :ignored_exceptions
 
       def initialize
         @app_name = ""
@@ -17,6 +18,7 @@ module Emque
         @rabbitmq_options = {
           :url => "amqp://guest:guest@localhost:5672"
         }
+        @ignored_exceptions = [Emque::Producing::Message::MessagesNotSentError]
       end
     end
   end

--- a/lib/emque/producing/publisher/rabbitmq.rb
+++ b/lib/emque/producing/publisher/rabbitmq.rb
@@ -5,6 +5,10 @@ module Emque
   module Producing
     module Publisher
       class RabbitMq < Emque::Producing::Publisher::Base
+        Emque::Producing.configure do |c|
+          c.ignored_exceptions = c.ignored_exceptions + [Bunny::Exception, Timeout::Error]
+        end
+
         CONN = Bunny
           .new(Emque::Producing.configuration.rabbitmq_options[:url])
           .tap { |conn|

--- a/lib/emque/producing/version.rb
+++ b/lib/emque/producing/version.rb
@@ -1,5 +1,5 @@
 module Emque
   module Producing
-    VERSION = "1.0.0"
+    VERSION = "1.0.1"
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,10 @@
 $TESTING = true
 
+require "simplecov"
+SimpleCov.start do
+  add_filter "spec/"
+end
+
 require "pry"
 require "emque-producing"
 


### PR DESCRIPTION
Move ignored exceptions into Message module
Allow publishers to add to the ignored exceptions, i.e. Publisher::RabbitMq adding bunny specific exceptions