### PR TITLE
ensure that you are dumping/loading as an object

### DIFF
--- a/lib/emque/producing/message/message_with_changeset.rb
+++ b/lib/emque/producing/message/message_with_changeset.rb
@@ -64,7 +64,7 @@ module Emque
       end
 
       def deep_copy(attr_set)
-        Oj.load(Oj.dump(attr_set))
+        Oj.load(Oj.dump(attr_set, :mode => :object), :mode => :object)
       end
 
       def translate(attr_set)


### PR DESCRIPTION
this is to restore default behavior if the default options are overridden. The primary difference I ran into is in the date formats, if using `compat` mode, dates are converted to strings in the `dump` and `load`