### PR TITLE
initial test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add these lines to your application's Gemfile, depending on your message broker:
 
     # for RabbitMQ, bunny is used
     gem "emque-producing"
-    gem "bunny", "~> 1.7"
+    gem "bunny", "~> 2.3"
 
 And then execute:
 
@@ -28,7 +28,7 @@ Or install it yourself as:
 ## Usage
 
     # configure (likely in a Rails initializer)
-    require 'emque-producing'
+    require "emque-producing"
     Emque::Producing.configure do |c|
       c.app_name = "app"
       c.publishing_adapter = :rabbitmq

--- a/emque-producing.gemspec
+++ b/emque-producing.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake",    "~> 10.4.2"
   spec.add_development_dependency "rspec",   "~> 3.2.0"
   spec.add_development_dependency "pry"
-  spec.add_development_dependency "bunny", "~> 1.7.0"
+  spec.add_development_dependency "bunny"
   spec.add_development_dependency "simplecov"
 end

--- a/lib/emque/producing/version.rb
+++ b/lib/emque/producing/version.rb
@@ -1,5 +1,5 @@
 module Emque
   module Producing
-    VERSION = "1.1.1"
+    VERSION = "1.2.0"
   end
 end

--- a/spec/slowdown.rb
+++ b/spec/slowdown.rb
@@ -1,0 +1,73 @@
+require "bunny"
+require "emque-producing"
+require "benchmark"
+
+class FooMessage
+  include Emque::Producing::Message
+  topic "foo"
+  message_type "foo.bar"
+  raise_on_failure false
+  attribute :foo, String, :required => true
+end
+
+Emque::Producing.configure do |c|
+  c.app_name = "publisher_confirms_tester"
+  c.publishing_adapter = :rabbitmq
+  c.rabbitmq_options[:url] = "amqp://guest:guest@localhost:5672"
+end
+
+# http://www.rabbitmq.com/confirms.html
+class PublisherConfirmsTester
+
+  #delete queues bound to foo exchange before running
+  def no_subscribed_queue
+    times = []
+    loop do
+      total_time = Benchmark.realtime do
+        message = FooMessage.new(:foo => "bar")
+        message.publish
+      end
+      times << total_time
+      puts "publish: #{total_time} avg: #{average(times)}"
+    end
+  end
+
+  def with_subscribed_queue
+    conn = Bunny.new
+    conn.start
+    ch   = conn.create_channel
+    x = ch.fanout("foo", :durable => true, :auto_delete => false)
+    puts "Exchange Created..."
+
+    #ch.queue("", :auto_delete => true).bind(x)
+    #ch.queue("", :auto_delete => false).bind(x)
+    ch.queue("foo.test", :auto_delete => false, :durable => true).bind(x)
+    puts "Queue bound..."
+    conn.close
+
+    times = []
+    10000.times do
+      total_time = Benchmark.realtime do
+        message = FooMessage.new(:foo => "bar")
+        message.publish
+      end
+      times << total_time
+      puts "publish: #{total_time} avg: #{average(times)}"
+    end
+  end
+
+  private
+
+  def median(array)
+    sorted = array.sort
+    len = sorted.size
+    (sorted[(len - 1) / 2] + sorted[len / 2]) / 2.0
+  end
+
+  def average(array)
+    array.inject(0){|sum,x| sum + x } / array.size
+  end
+end
+
+#PublisherConfirmsTester.new.no_subscribed_queue
+PublisherConfirmsTester.new.with_subscribed_queue


### PR DESCRIPTION
@knappe here's a sample script I was working on to reproduce the slowdown. It doesn't slowdown on my local rabbit as the queue is bound to the exchange and it backs up. So, it may have something to do with cluster/queue mirroring and perhaps this could be aimed at production to reproduce the slowdown?
