### PR TITLE
Lock simplecov to maintain Ruby 1.9.3 compatibility

### DIFF
--- a/emque-producing.gemspec
+++ b/emque-producing.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec",   "~> 3.2.0"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "bunny", "~> 1.7.0"
-  spec.add_development_dependency "simplecov"
+  spec.add_development_dependency "simplecov", "~> 0.11.2"
 end

--- a/lib/emque/producing/version.rb
+++ b/lib/emque/producing/version.rb
@@ -1,5 +1,5 @@
 module Emque
   module Producing
-    VERSION = "1.1.4"
+    VERSION = "1.1.5"
   end
 end


### PR DESCRIPTION
Gem was failing to install on Ruby 1.9.3 with Simplecov > 0.12