### PR TITLE
Fixes #50 drops support for Ruby 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: ruby
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.6
+  - 2.1.2
   - 2.2.2
   - 2.3.1
 script: bundle exec rake

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Emque Producing CHANGELOG
 
+- [Bump Ruby requirement to 2.1](https://github.com/emque/emque-producing/pull/51) (1.2.0)
 - [Optimize hostname lookups](https://github.com/emque/emque-producing/pull/47) (1.1.6)
 - [Maintain support for Ruby 1.9.3](https://github.com/emque/emque-producing/pull/49) (1.1.5)
 - [Return true or false when evalutating a valid message](https://github.com/emque/emque-producing/pull/45) (1.1.4)

--- a/emque-producing.gemspec
+++ b/emque-producing.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.description   = %q{Define and send messages to a variety of message brokers}
   spec.homepage      = ""
   spec.license       = "MIT"
-  spec.required_ruby_version = '>= 1.9.3'
+  spec.required_ruby_version = ">= 2.1"
 
   # Manifest
   spec.files         = `git ls-files`.split("\n")
@@ -28,6 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake",    "~> 10.4.2"
   spec.add_development_dependency "rspec",   "~> 3.2.0"
   spec.add_development_dependency "pry"
-  spec.add_development_dependency "bunny", "~> 1.7.0"
+  spec.add_development_dependency "bunny", "~> 2.5"
   spec.add_development_dependency "simplecov", "~> 0.11.2"
 end

--- a/lib/emque/producing/version.rb
+++ b/lib/emque/producing/version.rb
@@ -1,5 +1,5 @@
 module Emque
   module Producing
-    VERSION = "1.1.6"
+    VERSION = "1.2.0"
   end
 end


### PR DESCRIPTION
Drops support for Ruby 1.9. This could mean a potential re-merge of the 2 repos into one.