### PR TITLE
Avoid Socket error: getaddrinfo issue by simplifying setting the hostname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Emque Producing CHANGELOG
 
-- [Refine hostname lookups](https://github.com/emque/emque-producing/pull/56) (1.4.0)
+- [Refine hostname lookups](https://github.com/emque/emque-producing/pull/56) (1.3.1)
 - Bump Ruby requirement to 2.3 (1.3.0)
 - [Bump Ruby requirement to 2.1](https://github.com/emque/emque-producing/pull/51) (1.2.0)
 - [Optimize hostname lookups](https://github.com/emque/emque-producing/pull/47) (1.1.6)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Emque Producing CHANGELOG
 
+- [Refine hostname lookups](https://github.com/emque/emque-producing/pull/56) (1.4.0)
 - Bump Ruby requirement to 2.3 (1.3.0)
 - [Bump Ruby requirement to 2.1](https://github.com/emque/emque-producing/pull/51) (1.2.0)
 - [Optimize hostname lookups](https://github.com/emque/emque-producing/pull/47) (1.1.6)

--- a/lib/emque/producing/producing.rb
+++ b/lib/emque/producing/producing.rb
@@ -28,7 +28,7 @@ module Emque
 
       def hostname
         return @hostname unless @hostname.nil?
-        @hostname = Socket.gethostbyname(Socket.gethostname).first
+        @hostname = Socket.gethostname
         @hostname
       end
 

--- a/lib/emque/producing/version.rb
+++ b/lib/emque/producing/version.rb
@@ -1,5 +1,5 @@
 module Emque
   module Producing
-    VERSION = "1.4.0"
+    VERSION = "1.3.1"
   end
 end

--- a/lib/emque/producing/version.rb
+++ b/lib/emque/producing/version.rb
@@ -1,5 +1,5 @@
 module Emque
   module Producing
-    VERSION = "1.3.0"
+    VERSION = "1.4.0"
   end
 end


### PR DESCRIPTION
For some reason, it seems like certain MacOS environments are having trouble finding the addrinfo value for the hostname. This change gets around that. 