### PR TITLE
Add support for publishing to Cloud Pub/Sub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Emque Producing CHANGELOG
 
+- [Add ability to publish to Google Cloud Pub/Sub](https://github.com/emque/emque-producing/pull/57) (2.0.0.beta1)
 - [Update Rake to fix CVE-2020-8130](https://github.com/emque/emque-producing/pull/59) (1.3.2)
 - [Refine hostname lookups](https://github.com/emque/emque-producing/pull/56) (1.3.1)
 - Bump Ruby requirement to 2.3 (1.3.0)

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Or install it yourself as:
     require 'emque-producing'
     Emque::Producing.configure do |c|
       c.app_name = "app"
-      c.publiser :rabbitmq, url: "amqp://guest:guest@localhost:5672"
-      c.publiser :google_cloud_pubsub, project_id: "project", credentials: "credentials"
+      c.publisher :rabbitmq, url: "amqp://guest:guest@localhost:5672"
+      c.publisher :google_cloud_pubsub, project_id: "project", credentials: "credentials"
       c.error_handlers << Proc.new {|ex,context|
        # notify/log
       }

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Or install it yourself as:
     require 'emque-producing'
     Emque::Producing.configure do |c|
       c.app_name = "app"
-      c.publishing_adapter = :rabbitmq
+      c.publishing_adapter = [:rabbitmq]
       c.rabbitmq_options[:url] = "amqp://guest:guest@localhost:5672"
       c.error_handlers << Proc.new {|ex,context|
        # notify/log

--- a/emque-producing.gemspec
+++ b/emque-producing.gemspec
@@ -25,10 +25,10 @@ Gem::Specification.new do |spec|
   spec.add_dependency "oj",        "~> 2.10"
   spec.add_dependency "virtus",    "~> 1.0"
 
-  spec.add_development_dependency "rake", ">= 12.3.3"
-  spec.add_development_dependency "rspec", "~> 3.9.0"
-  spec.add_development_dependency "pry"
   spec.add_development_dependency "bunny", "~> 2.14"
   spec.add_development_dependency "google-cloud-pubsub", ">= 1.0"
+  spec.add_development_dependency "pry"
+  spec.add_development_dependency "rake", ">= 12.3.3"
+  spec.add_development_dependency "rspec", "~> 3.9.0"
   spec.add_development_dependency "simplecov", "~> 0.11.2"
 end

--- a/emque-producing.gemspec
+++ b/emque-producing.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["emily@teamsnap.com", "ryan.williams@teamsnap.com"]
   spec.summary       = %q{Define and send messages to a variety of message brokers}
   spec.description   = %q{Define and send messages to a variety of message brokers}
-  spec.homepage      = ""
+  spec.homepage      = "https://github.com/emque/emque-producing"
   spec.license       = "MIT"
   spec.required_ruby_version = ">= 2.3"
 
@@ -29,5 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.9.0"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "bunny", "~> 2.14"
+  spec.add_development_dependency "google-cloud-pubsub", ">= 1.0"
   spec.add_development_dependency "simplecov", "~> 0.11.2"
 end

--- a/emque-producing.gemspec
+++ b/emque-producing.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "bundler", ">= 1.3.0"
-  spec.add_dependency "oj",        "~> 2.10"
+  spec.add_dependency "oj",        ">= 2.10", "<= 4"
   spec.add_dependency "virtus",    "~> 1.0"
 
   spec.add_development_dependency "bunny", "~> 2.14"

--- a/emque-producing.gemspec
+++ b/emque-producing.gemspec
@@ -30,5 +30,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.9.0"
-  spec.add_development_dependency "simplecov", "~> 0.11.2"
 end

--- a/lib/emque/producing/configuration.rb
+++ b/lib/emque/producing/configuration.rb
@@ -14,7 +14,7 @@ module Emque
 
       def initialize
         @app_name = ""
-        @publishers = []
+        @publishers = {}
         @error_handlers = []
         @log_publish_message = false
         @publish_messages = true
@@ -33,7 +33,7 @@ module Emque
           raise "publisher not available"
         end
 
-        Emque::Producing.publishers[:adapter] = publishing_adapter
+        self.publishers[:adapter] = publishing_adapter
       end
 
       def use(callable)

--- a/lib/emque/producing/configuration.rb
+++ b/lib/emque/producing/configuration.rb
@@ -4,7 +4,7 @@ module Emque
 
     class Configuration
       attr_accessor :app_name
-      attr_accessor :publishing_adapter
+      attr_accessor :publishers
       attr_accessor :error_handlers
       attr_accessor :log_publish_message
       attr_accessor :publish_messages
@@ -15,7 +15,7 @@ module Emque
 
       def initialize
         @app_name = ""
-        @publishing_adapter = [:rabbitmq]
+        @publishers = []
         @error_handlers = []
         @log_publish_message = false
         @publish_messages = true

--- a/lib/emque/producing/configuration.rb
+++ b/lib/emque/producing/configuration.rb
@@ -25,10 +25,15 @@ module Emque
       def publisher(adapter, *args)
         if adapter == :rabbitmq
           require "emque/producing/publisher/rabbitmq"
-          publishing_adapter = Emque::Producing::Publisher::RabbitMq.new(url: args.first)
+          publishing_adapter = Emque::Producing::Publisher::RabbitMq.new(
+            url: args.first.fetch(:url)
+          )
         elsif adapter == :google_cloud_pubsub
           require "emque/producing/publisher/google_cloud_pubsub"
-          publishing_adapter = Emque::Producing::Publisher::GoogleCloudPubsub.new(project_id: args.first, credentials: args.last)
+          publishing_adapter = Emque::Producing::Publisher::GoogleCloudPubsub.new(
+            project_id: args.first.fetch(:project_id),
+            credentials: args.first.fetch(:credentials)
+          )
         else
           raise "publisher not available"
         end

--- a/lib/emque/producing/configuration.rb
+++ b/lib/emque/producing/configuration.rb
@@ -9,18 +9,20 @@ module Emque
       attr_accessor :log_publish_message
       attr_accessor :publish_messages
       attr_reader :rabbitmq_options
+      attr_reader :google_cloud_pubsub_options
       attr_accessor :ignored_exceptions
       attr_reader :middleware
 
       def initialize
         @app_name = ""
-        @publishing_adapter = :rabbitmq
+        @publishing_adapter = [:rabbitmq]
         @error_handlers = []
         @log_publish_message = false
         @publish_messages = true
         @rabbitmq_options = {
           :url => "amqp://guest:guest@localhost:5672"
         }
+        @google_cloud_pubsub_options = {}
         @ignored_exceptions = [Emque::Producing::Message::MessagesNotSentError]
         @middleware = []
       end

--- a/lib/emque/producing/message/message.rb
+++ b/lib/emque/producing/message/message.rb
@@ -129,6 +129,7 @@ module Emque
       end
 
       def publish_all
+        publish(publishers: Emque::Producing.publishers.keys)
       end
 
       def publish(publishers:)

--- a/lib/emque/producing/message/message.rb
+++ b/lib/emque/producing/message/message.rb
@@ -135,10 +135,11 @@ module Emque
           if Emque::Producing.configuration.publish_messages
             message = process_middleware(to_json)
             publishers.each do |publisher|
-              sent = Emque::Producing.publishers
+              sent = Emque::Producing
+                .publishers
                 .fetch(publisher)
                 .publish(topic, message_type, message, raise_on_failure?)
-              log "sent #{sent}"
+              log "publisher: #{publisher} sent: #{sent}"
               raise MessagesNotSentError.new unless sent
             end
           end
@@ -182,10 +183,14 @@ module Emque
         Emque::Producing.configuration.app_name || raise("Messages must have an app name configured.")
       end
 
+      def logger
+        Emque::Producing.logger
+      end
+
       def log(message, include_message = false)
         if Emque::Producing.configuration.log_publish_message
           message = "#{message} #{to_json}" if include_message
-          Emque::Producing.logger.info("MESSAGE LOG: #{message}")
+          logger.info("MESSAGE LOG: #{message}")
         end
       end
 

--- a/lib/emque/producing/message/message.rb
+++ b/lib/emque/producing/message/message.rb
@@ -128,9 +128,8 @@ module Emque
         Oj.dump(data, :mode => :compat)
       end
 
-      # def publish_all
-      #   publish
-      # end
+      def publish_all
+      end
 
       def publish(publishers:)
         log "publishing...", true

--- a/lib/emque/producing/message/message.rb
+++ b/lib/emque/producing/message/message.rb
@@ -75,7 +75,6 @@ module Emque
       def self.included(base)
         base.extend(ClassMethods)
         base.send(:include, Virtus.value_object)
-        base.send(:attribute, :partition_key, String, :default => nil, :required => false)
       end
 
       def add_metadata
@@ -88,7 +87,6 @@ module Emque
             :created_at => formatted_time,
             :uuid => uuid,
             :type => message_type,
-            :partition_key => partition_key
           }
         }.merge(public_attributes)
       end
@@ -137,7 +135,7 @@ module Emque
           log "valid...", true
           if Emque::Producing.configuration.publish_messages
             message = process_middleware(to_json)
-            sent = publisher.publish(topic, message_type, message, partition_key, raise_on_failure?)
+            sent = publisher.publish(topic, message_type, message, raise_on_failure?)
             log "sent #{sent}"
             raise MessagesNotSentError.new unless sent
           end

--- a/lib/emque/producing/message/message.rb
+++ b/lib/emque/producing/message/message.rb
@@ -128,7 +128,11 @@ module Emque
         Oj.dump(data, :mode => :compat)
       end
 
-      def publish(publishers=[:rabbitmq])
+      # def publish_all
+      #   publish
+      # end
+
+      def publish(publishers:)
         log "publishing...", true
         if valid?
           log "valid...", true

--- a/lib/emque/producing/message/message.rb
+++ b/lib/emque/producing/message/message.rb
@@ -129,14 +129,16 @@ module Emque
       end
 
       def publish(publisher=nil)
-        publisher ||= Emque::Producing.publisher
+        publishers ||= Emque::Producing.publishers
         log "publishing...", true
         if valid?
           log "valid...", true
           if Emque::Producing.configuration.publish_messages
             message = process_middleware(to_json)
-            sent = publisher.publish(topic, message_type, message, raise_on_failure?)
-            log "sent #{sent}"
+            publishers.each do |publisher|
+              sent = publisher.publish(topic, message_type, message, raise_on_failure?)
+              log "sent #{sent}"
+            end
             raise MessagesNotSentError.new unless sent
           end
         else

--- a/lib/emque/producing/producing.rb
+++ b/lib/emque/producing/producing.rb
@@ -3,6 +3,8 @@ module Emque
     class << self
       attr_writer :configuration
 
+      attr_accessor :publishers
+
       def message(opts = {})
         with_changeset = opts.fetch(:with_changeset) { false }
 
@@ -18,7 +20,7 @@ module Emque
       end
 
       def publishers
-        @publishers ||= get_publishers
+        @configuration.publishers
       end
 
       def configure
@@ -31,39 +33,6 @@ module Emque
 
       def hostname
         @hostname ||= Socket.gethostname
-      end
-
-      def get_publishers
-        publishers = {}
-
-        case configuration.publishing_adapter
-          when Symbol
-            if configuration.publishing_adapter == :rabbitmq
-              require "emque/producing/publisher/rabbitmq"
-              publishers[:rabbitmq] = Emque::Producing::Publisher::RabbitMq.new
-            elsif configuration.publishing_adapter == :google_cloud_pubsub
-              require "emque/producing/publisher/google_cloud_pubsub"
-              publishers[:google_cloud_pubsub] = Emque::Producing::Publisher::GoogleCloudPubsub.new
-            else
-              raise "No publisher configured"
-            end
-          when Array
-            if configuration.publishing_adapter.empty?
-              raise "No publisher configured"
-            end
-            if configuration.publishing_adapter.include?(:rabbitmq)
-              require "emque/producing/publisher/rabbitmq"
-              publishers[:rabbitmq] = Emque::Producing::Publisher::RabbitMq.new
-            end
-            if configuration.publishing_adapter.include?(:google_cloud_pubsub)
-              require "emque/producing/publisher/google_cloud_pubsub"
-              publishers[:google_cloud_pubsub] = Emque::Producing::Publisher::GoogleCloudPubsub.new
-            end
-          else
-            raise "No publisher configured"
-        end
-
-        publishers
       end
 
       def logger

--- a/lib/emque/producing/producing.rb
+++ b/lib/emque/producing/producing.rb
@@ -34,16 +34,16 @@ module Emque
       end
 
       def get_publishers
-        publishers = []
+        publishers = {}
 
         case configuration.publishing_adapter
           when Symbol
             if configuration.publishing_adapter == :rabbitmq
               require "emque/producing/publisher/rabbitmq"
-              publishers << Emque::Producing::Publisher::RabbitMq.new
+              publishers[:rabbitmq] = Emque::Producing::Publisher::RabbitMq.new
             elsif configuration.publishing_adapter == :google_cloud_pubsub
               require "emque/producing/publisher/google_cloud_pubsub"
-              publishers << Emque::Producing::Publisher::GoogleCloudPubsub.new
+              publishers[:google_cloud_pubsub] = Emque::Producing::Publisher::GoogleCloudPubsub.new
             else
               raise "No publisher configured"
             end
@@ -53,11 +53,11 @@ module Emque
             end
             if configuration.publishing_adapter.include?(:rabbitmq)
               require "emque/producing/publisher/rabbitmq"
-              publishers << Emque::Producing::Publisher::RabbitMq.new
+              publishers[:rabbitmq] = Emque::Producing::Publisher::RabbitMq.new
             end
             if configuration.publishing_adapter.include?(:google_cloud_pubsub)
               require "emque/producing/publisher/google_cloud_pubsub"
-              publishers << Emque::Producing::Publisher::GoogleCloudPubsub.new
+              publishers[:google_cloud_pubsub] = Emque::Producing::Publisher::GoogleCloudPubsub.new
             end
           else
             raise "No publisher configured"

--- a/lib/emque/producing/producing.rb
+++ b/lib/emque/producing/producing.rb
@@ -3,8 +3,6 @@ module Emque
     class << self
       attr_writer :configuration
 
-      attr_accessor :publishers
-
       def message(opts = {})
         with_changeset = opts.fetch(:with_changeset) { false }
 

--- a/lib/emque/producing/publisher/google_cloud_pubsub.rb
+++ b/lib/emque/producing/publisher/google_cloud_pubsub.rb
@@ -1,0 +1,44 @@
+require "google/cloud/pubsub"
+
+module Emque
+  module Producing
+    module Publisher
+      class GoogleCloudPubsub < Emque::Producing::Publisher::Base
+        def publish(topic_name, message_type, message, key = nil, raise_on_failure)
+          Emque::Producing.logger.info("GoogleCloudPubsub#publish")
+
+          pubsub = Google::Cloud::PubSub.new(
+            :project_id => Emque::Producing.configuration.google_cloud_pubsub_options[:project_id],
+            :credentials => Emque::Producing.configuration.google_cloud_pubsub_options[:credentials]
+          )
+
+          topic = pubsub.topic(topic_name)
+          if topic.nil?
+            Emque::Producing.logger.info("GoogleCloudPubsub Publisher: Creating topic #{topic_name}")
+            topic = pubsub.create_topic(topic_name)
+          end
+
+          Emque::Producing.logger.info("GoogleCloudPubsub Publisher: Publishing Message")
+          # msg = topic.publish(message)
+          sent = true
+          topic.publish_async(message) do |result|
+            if result.succeeded?
+              Emque::Producing.logger.info("GoogleCloudPubsub Publisher: Message succeeded")
+              Emque::Producing.logger.info(result.data)
+              sent = true
+            else
+              Emque::Producing.logger.warn("GoogleCloudPubsub Publisher: Message failed")
+              Emque::Producing.logger.warn(result.data)
+              Emque::Producing.logger.warn(result.error)
+              sent = false
+            end
+          end
+
+          topic.async_publisher.stop.wait!
+
+          sent
+        end
+      end
+    end
+  end
+end

--- a/lib/emque/producing/publisher/google_cloud_pubsub.rb
+++ b/lib/emque/producing/publisher/google_cloud_pubsub.rb
@@ -14,10 +14,10 @@ module Emque
         def publish(topic_name, message_type, message, raise_on_failure)
           Emque::Producing.logger.debug("GoogleCloudPubsub#publish")
 
-          topic = pubsub.topic(topic_name)
+          topic = pubsub.topic(message_type)
           if topic.nil?
             Emque::Producing.logger.info("GoogleCloudPubsub Publisher: Creating topic #{topic_name}")
-            topic = pubsub.create_topic(topic_name)
+            topic = pubsub.create_topic(message_type)
           end
 
           Emque::Producing.logger.info("GoogleCloudPubsub Publisher: Publishing Message")

--- a/lib/emque/producing/publisher/google_cloud_pubsub.rb
+++ b/lib/emque/producing/publisher/google_cloud_pubsub.rb
@@ -4,7 +4,7 @@ module Emque
   module Producing
     module Publisher
       class GoogleCloudPubsub < Emque::Producing::Publisher::Base
-        def publish(topic_name, message_type, message, key = nil, raise_on_failure)
+        def publish(topic_name, message_type, message, raise_on_failure)
           Emque::Producing.logger.info("GoogleCloudPubsub#publish")
 
           pubsub = Google::Cloud::PubSub.new(

--- a/lib/emque/producing/publisher/google_cloud_pubsub.rb
+++ b/lib/emque/producing/publisher/google_cloud_pubsub.rb
@@ -4,15 +4,15 @@ module Emque
   module Producing
     module Publisher
       class GoogleCloudPubsub < Emque::Producing::Publisher::Base
-        def initialize
+        def initialize(project_id:, credentials:)
           self.pubsub = Google::Cloud::PubSub.new(
-            :project_id => Emque::Producing.configuration.google_cloud_pubsub_options[:project_id],
-            :credentials => Emque::Producing.configuration.google_cloud_pubsub_options[:credentials]
+            :project_id => project_id
+            :credentials => credentials
           )
         end
 
         def publish(topic_name, message_type, message, raise_on_failure)
-          # Emque::Producing.logger.info("GoogleCloudPubsub#publish")
+          Emque::Producing.logger.debug("GoogleCloudPubsub#publish")
 
           topic = pubsub.topic(topic_name)
           if topic.nil?
@@ -21,12 +21,11 @@ module Emque
           end
 
           Emque::Producing.logger.info("GoogleCloudPubsub Publisher: Publishing Message")
-          # msg = topic.publish(message)
           sent = true
           topic.publish_async(message) do |result|
             if result.succeeded?
               Emque::Producing.logger.info("GoogleCloudPubsub Publisher: Message succeeded")
-              Emque::Producing.logger.info(result.data)
+              Emque::Producing.logger.debug(result.data)
               sent = true
             else
               Emque::Producing.logger.warn("GoogleCloudPubsub Publisher: Message failed")

--- a/lib/emque/producing/publisher/google_cloud_pubsub.rb
+++ b/lib/emque/producing/publisher/google_cloud_pubsub.rb
@@ -4,13 +4,15 @@ module Emque
   module Producing
     module Publisher
       class GoogleCloudPubsub < Emque::Producing::Publisher::Base
-        def publish(topic_name, message_type, message, raise_on_failure)
-          Emque::Producing.logger.info("GoogleCloudPubsub#publish")
-
-          pubsub = Google::Cloud::PubSub.new(
+        def initialize
+          self.pubsub = Google::Cloud::PubSub.new(
             :project_id => Emque::Producing.configuration.google_cloud_pubsub_options[:project_id],
             :credentials => Emque::Producing.configuration.google_cloud_pubsub_options[:credentials]
           )
+        end
+
+        def publish(topic_name, message_type, message, raise_on_failure)
+          # Emque::Producing.logger.info("GoogleCloudPubsub#publish")
 
           topic = pubsub.topic(topic_name)
           if topic.nil?
@@ -38,6 +40,8 @@ module Emque
 
           sent
         end
+
+        attr_accessor :pubsub
       end
     end
   end

--- a/lib/emque/producing/publisher/google_cloud_pubsub.rb
+++ b/lib/emque/producing/publisher/google_cloud_pubsub.rb
@@ -6,8 +6,8 @@ module Emque
       class GoogleCloudPubsub < Emque::Producing::Publisher::Base
         def initialize(project_id:, credentials:)
           self.pubsub = Google::Cloud::PubSub.new(
-            :project_id => project_id,
-            :credentials => credentials
+            :project_id => project_id
+            # :credentials => credentials # only works when reading directly from ENV
           )
         end
 

--- a/lib/emque/producing/publisher/rabbitmq.rb
+++ b/lib/emque/producing/publisher/rabbitmq.rb
@@ -15,13 +15,7 @@ module Emque
         end
 
         def initialize(url:)
-          @connection ||= Bunny.new(url).tap {
-            |conn| conn.start
-          }
-        end
-
-        def initialize
-          self.connection = Bunny.new.tap { |conn|
+          self.connection = Bunny.new(url).tap { |conn|
             conn.start
           }
           self.channel_pool = Queue.new.tap { |queue|

--- a/lib/emque/producing/publisher/rabbitmq.rb
+++ b/lib/emque/producing/publisher/rabbitmq.rb
@@ -5,8 +5,17 @@ module Emque
   module Producing
     module Publisher
       class RabbitMq < Emque::Producing::Publisher::Base
+
+        attr_accessor :connection
+
         Emque::Producing.configure do |c|
           c.ignored_exceptions = c.ignored_exceptions + [Bunny::Exception, Timeout::Error]
+        end
+
+        def initialize(url:)
+          @connection ||= Bunny.new(url]).tap {
+            |conn| conn.start
+          }
         end
 
         CONN = Bunny

--- a/lib/emque/producing/publisher/rabbitmq.rb
+++ b/lib/emque/producing/publisher/rabbitmq.rb
@@ -15,7 +15,7 @@ module Emque
         end
 
         def initialize(url:)
-          @connection ||= Bunny.new(url]).tap {
+          @connection ||= Bunny.new(url).tap {
             |conn| conn.start
           }
         end

--- a/lib/emque/producing/publisher/rabbitmq.rb
+++ b/lib/emque/producing/publisher/rabbitmq.rb
@@ -6,7 +6,6 @@ module Emque
     module Publisher
       class RabbitMq < Emque::Producing::Publisher::Base
         attr_accessor :connection
-        attr_accessor :connection
         attr_accessor :channel_pool
         attr_accessor :confirms_channel_pool
 

--- a/lib/emque/producing/publisher/rabbitmq.rb
+++ b/lib/emque/producing/publisher/rabbitmq.rb
@@ -18,7 +18,7 @@ module Emque
         }
         CHANNEL_POOL = Queue.new.tap { |queue| queue << CONN.create_channel }
 
-        def publish(topic, message_type, message, key = nil, raise_on_failure)
+        def publish(topic, message_type, message, raise_on_failure)
           ch = get_channel(raise_on_failure)
 
           ch.open if ch.closed?

--- a/lib/emque/producing/version.rb
+++ b/lib/emque/producing/version.rb
@@ -1,5 +1,5 @@
 module Emque
   module Producing
-    VERSION = "1.3.2"
+    VERSION = "2.0.0.beta1"
   end
 end

--- a/spec/producing/message/message_spec.rb
+++ b/spec/producing/message/message_spec.rb
@@ -314,7 +314,7 @@ describe Emque::Producing::Message do
         allow(Emque::Producing).to receive(:publishers) { {:test => publisher} }
         allow(publisher).to receive(:publish).and_raise(TestPublisher::InvalidMessageError)
 
-        expect{message.publish([:test])}.not_to raise_error
+        expect{message.publish(publishers: [:test])}.not_to raise_error
       end
 
       it "rescues exceptions when publish doesn't send" do
@@ -323,7 +323,7 @@ describe Emque::Producing::Message do
         allow(Emque::Producing).to receive(:publishers) { {:test => publisher} }
         allow(publisher).to receive(:publish) { false }
 
-        expect{message.publish([:test])}.not_to raise_error
+        expect{message.publish(publishers: [:test])}.not_to raise_error
       end
 
       it "rescues exceptions that are in the ignored list of excpetions" do
@@ -332,7 +332,7 @@ describe Emque::Producing::Message do
         allow(Emque::Producing).to receive(:publishers) { {:test => publisher} }
         allow(publisher).to receive(:publish).and_raise(TestMessageDontRaiseOnFailure::IgnoreThisError)
 
-        expect{message.publish([:test])}.not_to raise_error
+        expect{message.publish(publishers: [:test])}.not_to raise_error
       end
 
       it "doesnt catch an exceptions that isn't in the " do
@@ -341,7 +341,7 @@ describe Emque::Producing::Message do
         allow(Emque::Producing).to receive(:publishers) { {:test => publisher} }
         allow(publisher).to receive(:publish).and_raise(TestMessageDontRaiseOnFailure::DontIgnoreThisError)
 
-        expect{message.publish([:test])}.to raise_error(TestMessageDontRaiseOnFailure::DontIgnoreThisError)
+        expect{message.publish(publishers: [:test])}.to raise_error(TestMessageDontRaiseOnFailure::DontIgnoreThisError)
       end
     end
 
@@ -357,7 +357,7 @@ describe Emque::Producing::Message do
         allow(Emque::Producing).to receive(:publishers) { {:test => publisher} }
         allow(publisher).to receive(:publish).and_raise(TestPublisher::InvalidMessageError)
 
-        expect{message.publish([:test])}.to raise_error(TestPublisher::InvalidMessageError)
+        expect{message.publish(publishers: [:test])}.to raise_error(TestPublisher::InvalidMessageError)
       end
 
       it "raises exceptions when publish doesn't send" do
@@ -366,7 +366,7 @@ describe Emque::Producing::Message do
         allow(Emque::Producing).to receive(:publishers) { {:test => publisher} }
         allow(publisher).to receive(:publish) { false }
 
-        expect{message.publish([:test])}.to raise_error(Emque::Producing::Message::MessagesNotSentError)
+        expect{message.publish(publishers: [:test])}.to raise_error(Emque::Producing::Message::MessagesNotSentError)
       end
     end
   end

--- a/spec/producing/message/message_spec.rb
+++ b/spec/producing/message/message_spec.rb
@@ -164,19 +164,19 @@ describe Emque::Producing::Message do
   it "raises a useful message when trying to send an invalid message" do
     message = TestMessage.new()
     expected_error = Emque::Producing::Message::InvalidMessageError
-    expect{message.publish(->{})}.to raise_error(expected_error)
+    expect{message.publish(publishers: [])}.to raise_error(expected_error)
   end
 
   it "validates that the message has a topic" do
     message = MessageNoTopic.new
     expected_error = Emque::Producing::Message::InvalidMessageError
-    expect{message.publish(->{})}.to raise_error(expected_error, "A topic is required")
+    expect{message.publish(publishers: [])}.to raise_error(expected_error, "A topic is required")
   end
 
   it "validates that the message has a message type" do
     message = MessageNoType.new
     expected_error = Emque::Producing::Message::InvalidMessageError
-    expect{message.publish(->{})}.to raise_error(expected_error, "A message type is required")
+    expect{message.publish(publishers: [])}.to raise_error(expected_error, "A message type is required")
   end
 
   it "applys a uuid per message" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,5 @@
 $TESTING = true
 
-require "simplecov"
-SimpleCov.start do
-  add_filter "spec/"
-end
-
 require "pry"
 require "emque-producing"
 


### PR DESCRIPTION
Goals:

1. Allow producing applications to publish messages to [Google Cloud Pub/Sub](https://cloud.google.com/pubsub/docs/quickstart-client-libraries)
2. Producing applications can specify rabbitmq or google cloud pubsub adapters

Questions:

What if an applications wants to publish some messages to rabbit and some to cloud pub/sub, can the configuration be extended to support multiple adapters and not one or the other?  Then the message could specify which adapter?


Example of creating topic and publishing a message:
```
pry(main)> require "google/cloud/pubsub"
pry(main)> pubsub = Google::Cloud::PubSub.new(:project_id => "[project name]")
pry(main)> topic = pubsub.topic("members")
=> nil

pry(main)> topic = pubsub.create_topic("members")
=> #<Google::Cloud::PubSub::Topic:0x0000555a02b492c0
 @async_opts={},
 @exists=nil,
 @grpc=<Google::Cloud::PubSub::V1::Topic: name: "projects/[project name]/topics/members", labels: {}, message_storage_policy: nil, kms_key_name: "">,
 @resource_name=nil,
 @service=#<Google::Cloud::PubSub::Service [project_name>>

pry(main)> topic.publish "This is a test message."
=> #<Google::Cloud::PubSub::Message:0x0000555a02910490
 @grpc=<Google::Cloud::PubSub::V1::PubsubMessage: data: "This is a test message.", attributes: {}, message_id: "443194934033393", publish_time: nil, ordering_key: "">>
```

Design goal for producing applications

```
Emque::Producing.configure do |c|
  c.app_name = ENV["MESSAGE_QUEUE_APP_NAME"]
  c.publishing_adapter = [:rabbitmq, :google_cloud_pubsub] 
  c.rabbitmq_options[:url] = ENV["RABBITMQ_URL"]
  c.google_cloud_pubsub_options[:project_id] = ENV["GOOGLE_CLOUD_PUBSUB_PROJECT"]
  c.google_cloud_pubsub_options[:credentials] = ENV["GOOGLE_CLOUD_PUBSUB_CREDENTIALS"]
end
MemberCreatedMessage.new(:user_id => 1).publish([:google_cloud_pubsub, :rabbitmq])
```