### PR TITLE
Fixes security alert on Rake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: ruby
 rvm:
-  - 2.3.4
   - 2.3.8
-  - 2.4.5
-  - 2.5.3
-  - 2.6.3
+  - 2.4.10
+  - 2.5.8
+  - 2.6.6
 script: bundle exec rake
 notifications:
   recipients:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Emque Producing CHANGELOG
 
+- [Update Rake to fix CVE-2020-8130](https://github.com/emque/emque-producing/pull/59) (1.3.2)
 - [Refine hostname lookups](https://github.com/emque/emque-producing/pull/56) (1.3.1)
 - Bump Ruby requirement to 2.3 (1.3.0)
 - [Bump Ruby requirement to 2.1](https://github.com/emque/emque-producing/pull/51) (1.2.0)

--- a/emque-producing.gemspec
+++ b/emque-producing.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "virtus",    "~> 1.0"
   spec.add_dependency "bundler", ">= 1.3.0"
 
-  spec.add_development_dependency "rake",    "~> 10.4.2"
+  spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec",   "~> 3.2.0"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "bunny", "~> 2.5"

--- a/emque-producing.gemspec
+++ b/emque-producing.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "bundler", ">= 1.3.0"
 
   spec.add_development_dependency "rake", ">= 12.3.3"
-  spec.add_development_dependency "rspec",   "~> 3.2.0"
+  spec.add_development_dependency "rspec", "~> 3.9.0"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "bunny", "~> 2.5"
   spec.add_development_dependency "simplecov", "~> 0.11.2"

--- a/emque-producing.gemspec
+++ b/emque-producing.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.9.0"
   spec.add_development_dependency "pry"
-  spec.add_development_dependency "bunny", "~> 2.5"
+  spec.add_development_dependency "bunny", "~> 2.14"
   spec.add_development_dependency "simplecov", "~> 0.11.2"
 end

--- a/lib/emque/producing/version.rb
+++ b/lib/emque/producing/version.rb
@@ -1,5 +1,5 @@
 module Emque
   module Producing
-    VERSION = "1.3.1"
+    VERSION = "1.3.2"
   end
 end


### PR DESCRIPTION
Fix for CVE-2020-8130

* https://github.com/advisories/GHSA-jppv-gw3r-w3q8
* https://github.com/emque/emque-producing/network/alert/emque-producing.gemspec/rake/open
