### PR TITLE
Deprecate publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Emque Producing CHANGELOG
 
+## 1.4.0
+
+- [Deprecated: publish on message will be removed in favor of having publishers publish](https://github.com/emque/emque-producing/pull/60)
+- [Removed: Partition Key from message](https://github.com/emque/emque-producing/pull/60)
+
+
+## Older
+
 - [Update Rake to fix CVE-2020-8130](https://github.com/emque/emque-producing/pull/59) (1.3.2)
 - [Refine hostname lookups](https://github.com/emque/emque-producing/pull/56) (1.3.1)
 - Bump Ruby requirement to 2.3 (1.3.0)

--- a/README.md
+++ b/README.md
@@ -49,9 +49,14 @@ Or install it yourself as:
       end
     end
 
-    # produce message
+    # Current, deprecated method to produce a message
     message = MyMessage.new({:first_property => 1, :another_property => "another"})
     message.publish
+
+    # future direction in v2
+    message = MyMessage.new({:first_property => 1, :another_property => "another"})
+    Emque::Producing::Publisher::RabbitMq.new.publish(message)
+    Emque::Producing::Publisher::GoogleCloudPubSub.new.publish(message)
 
     # create a message class including changesets
     class MyChangesetMessage
@@ -88,9 +93,9 @@ applications, [please read the wiki entry](https://github.com/emque/emque-produc
 
 ## Requirements
 
-* Ruby 1.9.3 or higher
+* Ruby 2.3 or higher
 * RabbitMQ 3.x
-* Bunny 1.4.x
+* Bunny 2.x
 
 ## Tests
 

--- a/emque-producing.gemspec
+++ b/emque-producing.gemspec
@@ -20,6 +20,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
+  spec.metadata    = {
+    "changelog_uri" => "https://github.com/emque/emque-producing/blob/master/CHANGELOG.md",
+  }
 
   spec.add_dependency "oj",        "~> 2.10"
   spec.add_dependency "virtus",    "~> 1.0"

--- a/lib/emque/producing/message/message.rb
+++ b/lib/emque/producing/message/message.rb
@@ -75,7 +75,6 @@ module Emque
       def self.included(base)
         base.extend(ClassMethods)
         base.send(:include, Virtus.value_object)
-        base.send(:attribute, :partition_key, String, :default => nil, :required => false)
       end
 
       def add_metadata
@@ -87,8 +86,7 @@ module Emque
             :topic => topic,
             :created_at => formatted_time,
             :uuid => uuid,
-            :type => message_type,
-            :partition_key => partition_key
+            :type => message_type
           }
         }.merge(public_attributes)
       end
@@ -137,7 +135,7 @@ module Emque
           log "valid...", true
           if Emque::Producing.configuration.publish_messages
             message = process_middleware(to_json)
-            sent = publisher.publish(topic, message_type, message, partition_key, raise_on_failure?)
+            sent = publisher.publish(topic, message_type, message, raise_on_failure?)
             log "sent #{sent}"
             raise MessagesNotSentError.new unless sent
           end

--- a/lib/emque/producing/message/message.rb
+++ b/lib/emque/producing/message/message.rb
@@ -129,6 +129,8 @@ module Emque
       end
 
       def publish(publisher=nil)
+        warn "[DEPRECATION] `publish` is deprecated. Publishers should publish, message should not"
+
         publisher ||= Emque::Producing.publisher
         log "publishing...", true
         if valid?

--- a/lib/emque/producing/message/message_with_changeset.rb
+++ b/lib/emque/producing/message/message_with_changeset.rb
@@ -11,7 +11,6 @@ module Emque
       def self.included(base)
         base.extend(ClassMethods)
         base.send(:include, Emque::Producing::Message)
-        base.send(:attribute, :partition_key, String, :default => nil, :required => false)
         base.send(:attribute, :change_set, Hash, :default => :build_change_set, :required => true)
         base.send(:private_attribute, :updated)
         base.send(:private_attribute, :original)

--- a/lib/emque/producing/publisher/rabbitmq.rb
+++ b/lib/emque/producing/publisher/rabbitmq.rb
@@ -18,7 +18,7 @@ module Emque
         }
         CHANNEL_POOL = Queue.new.tap { |queue| queue << CONN.create_channel }
 
-        def publish(topic, message_type, message, key = nil, raise_on_failure)
+        def publish(topic, message_type, message, raise_on_failure)
           ch = get_channel(raise_on_failure)
 
           ch.open if ch.closed?

--- a/lib/emque/producing/version.rb
+++ b/lib/emque/producing/version.rb
@@ -1,5 +1,5 @@
 module Emque
   module Producing
-    VERSION = "1.3.2"
+    VERSION = "1.4.0"
   end
 end


### PR DESCRIPTION
Prepare to start separating messages from publish. Publishers should publish as multiple publishers become a reality.