### PR TITLE
Update oj gem

### DIFF
--- a/emque-producing.gemspec
+++ b/emque-producing.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "oj",        "~> 2.10"
+  spec.add_dependency "oj",        ">= 2.10"
   spec.add_dependency "virtus",    "~> 1.0"
   spec.add_dependency "bundler", ">= 1.3.0"
 


### PR DESCRIPTION
In order to complete a Snapi Rails 6 upgrade, we need to update the emque-producing's oj gem to a higher version. Please see note [here](https://teamsnap.atlassian.net/browse/BCB-1819?focusedCommentId=140232). 

Related to [BCB-1819](https://teamsnap.atlassian.net/browse/BCB-1819) - Rails6 needs to support creating a new location.

